### PR TITLE
Analyze the content in current editor when its saved

### DIFF
--- a/src/Sarif.Sarifer.Core/BackgroundAnalysisTextViewCreationListener.cs
+++ b/src/Sarif.Sarifer.Core/BackgroundAnalysisTextViewCreationListener.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
         private const string AnyContentType = "any";
         private SarifViewerInterop sarifViewerInterop;
 
-        // private TextEditIdleAssistant inputAssistant;
         private bool subscribed;
         private bool disposed;
         private int isRunning;
@@ -78,7 +77,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 this.textBufferViewTracker.FirstViewAdded += this.TextBufferViewTracker_FirstViewAdded;
                 this.textBufferViewTracker.LastViewRemoved += this.TextBufferViewTracker_LastViewRemoved;
 
-                // this.textBufferViewTracker.ViewUpdated += this.TextBufferViewTracker_ViewUpdated;
                 this.subscribed = true;
             }
 
@@ -88,19 +86,6 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             string path = this.GetPathFromTextView(textView);
 
             textView.Closed += (object sender, EventArgs e) => this.TextView_Closed(textView);
-
-            /*
-            // TextBuffer.Changed event is a performance critical event, whose handlers directly affect typing responsiveness.
-            // Unless it's required to handle this event synchronously on the UI thread.
-            // As suggested listen to Microsoft.VisualStudio.Text.ITextBuffer2.ChangedOnBackground event instead.
-            if (textView.TextBuffer is VisualStudio.Text.ITextBuffer2 oldBuffer)
-            {
-                oldBuffer.ChangedOnBackground += (object sender, VisualStudio.Text.TextContentChangedEventArgs e) => this.TextBuffer_ChangedOnBackground(textView);
-            }
-
-            this.inputAssistant = new TextEditIdleAssistant();
-            this.inputAssistant.Idled += this.InputAssistant_Idled;
-            */
 
             this.textBufferViewTracker.AddTextView(textView, path, text);
         }
@@ -118,33 +103,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 if (disposing)
                 {
                     this.textBufferViewTracker?.Clear();
-
-                    // this.inputAssistant?.Dispose();
                 }
 
                 this.disposed = true;
             }
         }
-
-        /*
-        private void InputAssistant_Idled(object sender, TextEditIdledEventArgs e)
-        {
-            ITextView textView = e.TextView;
-            string text = textView.TextBuffer.CurrentSnapshot.GetText();
-            this.textBufferViewTracker.UpdateTextView(textView, text);
-        }
-
-        private void TextBufferViewTracker_ViewUpdated(object sender, ViewUpdatedEventArgs e)
-        {
-            // this.BackgroundAnalyzeAsync(e.Path, e.Text, e.CancellationToken)
-            //     .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
-        }
-
-        private void TextBuffer_ChangedOnBackground(ITextView textView)
-        {
-            this.inputAssistant.TextChanged(new TextEditIdledEventArgs(textView));
-        }
-        */
 
         private void TextBufferViewTracker_FirstViewAdded(object sender, FirstViewAddedEventArgs e)
         {

--- a/src/Sarif.Sarifer.Core/BackgroundAnalysisTextViewCreationListener.cs
+++ b/src/Sarif.Sarifer.Core/BackgroundAnalysisTextViewCreationListener.cs
@@ -28,7 +28,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
     {
         private const string AnyContentType = "any";
         private SarifViewerInterop sarifViewerInterop;
-        private TextEditIdleAssistant inputAssistant;
+
+        // private TextEditIdleAssistant inputAssistant;
         private bool subscribed;
         private bool disposed;
         private int isRunning;
@@ -76,7 +77,8 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 // is loaded.
                 this.textBufferViewTracker.FirstViewAdded += this.TextBufferViewTracker_FirstViewAdded;
                 this.textBufferViewTracker.LastViewRemoved += this.TextBufferViewTracker_LastViewRemoved;
-                this.textBufferViewTracker.ViewUpdated += this.TextBufferViewTracker_ViewUpdated;
+
+                // this.textBufferViewTracker.ViewUpdated += this.TextBufferViewTracker_ViewUpdated;
                 this.subscribed = true;
             }
 
@@ -87,6 +89,7 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
             textView.Closed += (object sender, EventArgs e) => this.TextView_Closed(textView);
 
+            /*
             // TextBuffer.Changed event is a performance critical event, whose handlers directly affect typing responsiveness.
             // Unless it's required to handle this event synchronously on the UI thread.
             // As suggested listen to Microsoft.VisualStudio.Text.ITextBuffer2.ChangedOnBackground event instead.
@@ -95,10 +98,11 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
                 oldBuffer.ChangedOnBackground += (object sender, VisualStudio.Text.TextContentChangedEventArgs e) => this.TextBuffer_ChangedOnBackground(textView);
             }
 
-            this.textBufferViewTracker.AddTextView(textView, path, text);
-
             this.inputAssistant = new TextEditIdleAssistant();
             this.inputAssistant.Idled += this.InputAssistant_Idled;
+            */
+
+            this.textBufferViewTracker.AddTextView(textView, path, text);
         }
 
         public void Dispose()
@@ -113,14 +117,16 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
             {
                 if (disposing)
                 {
-                    this.textBufferViewTracker.Clear();
-                    this.inputAssistant.Dispose();
+                    this.textBufferViewTracker?.Clear();
+
+                    // this.inputAssistant?.Dispose();
                 }
 
                 this.disposed = true;
             }
         }
 
+        /*
         private void InputAssistant_Idled(object sender, TextEditIdledEventArgs e)
         {
             ITextView textView = e.TextView;
@@ -130,14 +136,15 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
         private void TextBufferViewTracker_ViewUpdated(object sender, ViewUpdatedEventArgs e)
         {
-            this.BackgroundAnalyzeAsync(e.Path, e.Text, e.CancellationToken)
-                .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
+            // this.BackgroundAnalyzeAsync(e.Path, e.Text, e.CancellationToken)
+            //     .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
         }
 
         private void TextBuffer_ChangedOnBackground(ITextView textView)
         {
             this.inputAssistant.TextChanged(new TextEditIdledEventArgs(textView));
         }
+        */
 
         private void TextBufferViewTracker_FirstViewAdded(object sender, FirstViewAddedEventArgs e)
         {

--- a/src/Sarif.Sarifer.Core/RunningDocTableEventsHandler.cs
+++ b/src/Sarif.Sarifer.Core/RunningDocTableEventsHandler.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.CodeAnalysis.Sarif.Sarifer
+{
+    internal class RunningDocTableEventsHandler : IVsRunningDocTableEvents3
+    {
+        private readonly RunningDocumentTable runningDocTable;
+
+        private readonly IBackgroundAnalysisService backgroundAnalysisService;
+
+        private int isRunning;
+
+        internal RunningDocTableEventsHandler(IServiceProvider serviceProvider)
+        {
+            this.runningDocTable = new RunningDocumentTable(serviceProvider);
+
+            var componentModel = (IComponentModel)Package.GetGlobalService(typeof(SComponentModel));
+
+            if (componentModel != null)
+            {
+                this.backgroundAnalysisService = componentModel.GetService<IBackgroundAnalysisService>();
+            }
+        }
+
+        // IVsRunningDocTableEvents
+        public int OnAfterFirstDocumentLock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeLastDocumentUnlock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterSave(uint docCookie)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterAttributeChange(uint docCookie, uint grfAttribs)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeDocumentWindowShow(uint docCookie, int fFirstShow, IVsWindowFrame pFrame)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnAfterDocumentWindowHide(uint docCookie, IVsWindowFrame pFrame)
+        {
+            return VSConstants.S_OK;
+        }
+
+        // IVsRunningDocTableEvents2
+        public int OnAfterAttributeChangeEx(uint docCookie, uint grfAttribs, IVsHierarchy pHierOld, uint itemidOld, string pszMkDocumentOld, IVsHierarchy pHierNew, uint itemidNew, string pszMkDocumentNew)
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int OnBeforeSave(uint docCookie)
+        {
+            if (this.runningDocTable != null && docCookie != 0 && this.backgroundAnalysisService != null)
+            {
+                this.BackgroundAnalyzeAsync(
+                    this.runningDocTable.GetDocumentInfo(docCookie).Moniker,
+                    this.runningDocTable.GetRunningDocumentContents(docCookie),
+                    default)
+                    .FileAndForget(FileAndForgetEventName.BackgroundAnalysisFailure);
+            }
+
+            return VSConstants.S_OK;
+        }
+
+        private async System.Threading.Tasks.Task BackgroundAnalyzeAsync(string path, string text, CancellationToken cancellationToken)
+        {
+            if (!this.IsRunning())
+            {
+                this.SetRun(true);
+                try
+                {
+                    await System.Threading.Tasks.TaskScheduler.Default;
+
+                    await this.backgroundAnalysisService.AnalyzeAsync(path, text, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    this.SetRun(false);
+                }
+            }
+        }
+
+        private bool IsRunning() => Interlocked.CompareExchange(ref this.isRunning, 1, 1) == 1;
+
+        private bool SetRun(bool run) => (run ?
+            Interlocked.CompareExchange(ref this.isRunning, 1, 0) : Interlocked.CompareExchange(ref this.isRunning, 0, 1)) == 1;
+    }
+}

--- a/src/Sarif.Sarifer.Core/Sarif.Sarifer.Core.projitems
+++ b/src/Sarif.Sarifer.Core/Sarif.Sarifer.Core.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Options\SariferOptionsPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OutputWindowTracerListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Constants.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RunningDocTableEventsHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SariferPackage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SariferPackageCommandIds.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SarifViewerBackgroundAnalysisSink.cs" />

--- a/src/Sarif.Sarifer.Core/SariferPackage.cs
+++ b/src/Sarif.Sarifer.Core/SariferPackage.cs
@@ -93,6 +93,10 @@ namespace Microsoft.CodeAnalysis.Sarif.Sarifer
 
             SolutionEvents.OnBeforeCloseSolution += this.SolutionEvents_OnBeforeCloseSolution;
 
+            // handle RunningDocTable events
+            var runningDocumentTable = GetGlobalService(typeof(SVsRunningDocumentTable)) as IVsRunningDocumentTable;
+            runningDocumentTable.AdviseRunningDocTableEvents(new RunningDocTableEventsHandler(ServiceProvider.GlobalProvider), out uint cookie);
+
             await SariferOption.InitializeAsync(this).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
# Description

Current extension starts background analysis every 3 seconds after users stop typing in the editor. 

It slows down the VS a bit, and we decide to only analyze the content when user saves.